### PR TITLE
update mapbox gl version to fix broken style link

### DIFF
--- a/mapbox.js
+++ b/mapbox.js
@@ -26,8 +26,8 @@ var FILES = {
   },
 
   mapboxgl: {
-    js:   ['https://api.tiles.mapbox.com/mapbox-gl-js/v0.8.1/mapbox-gl.js'],
-    css:  ['https://api.tiles.mapbox.com/mapbox-gl-js/v0.8.1/mapbox-gl.css'],
+    js:   ['https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.4/mapbox-gl.js'],
+    css:  ['https://api.tiles.mapbox.com/mapbox-gl-js/v0.11.4/mapbox-gl.css'],
   },
 
   turf: {


### PR DESCRIPTION
The old version generated a faulty style url that returned a 404

404:

```
https://a.tiles.mapbox.com/styles/v1/styles/mapbox/dark-v8/styles/mapbox/dark-v8?access_token=pk.eyJ1IjoiamF2b2lyZSIsImEiOiI0RlhyV1g0In0.S1g0HqgesWeRvVfPENPTHA
```

Correct url

```
https://api.mapbox.com/styles/v1/mapbox/dark-v8?access_token=pk.eyJ1IjoiamF2b2lyZSIsImEiOiI0RlhyV1g0In0.S1g0HqgesWeRvVfPENPTHA
```
