### PR TITLE
Fixed URL of locate plugin

### DIFF
--- a/mapbox.js
+++ b/mapbox.js
@@ -76,7 +76,7 @@ var FILES = {
   // FIXME: Doesn't support IE<9
   // https://www.mapbox.com/mapbox.js/example/v1.0.0/leaflet-locatecontrol/
   locate: {
-    js:   ['https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-locatecontrol/v0.43.0/L.Control.Locate.js'],
+    js:   ['https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-locatecontrol/v0.43.0/L.Control.Locate.min.js'],
     css:  ['https://api.tiles.mapbox.com/mapbox.js/plugins/leaflet-locatecontrol/v0.43.0/L.Control.Locate.css']
   },
 


### PR DESCRIPTION
Current URL was a 404 Error. 
At the moment it seems that only the minified version of the js file is available from mapbox.